### PR TITLE
Add options, `--node` and `--modules`

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ iex(example@nerves.local)1> Example.hello
 
 It's much faster than `mix firmware && mix upload`.
 
+### Options
+
+#### --node
+
+You can specify the node(s) in the cluster as below:
+
+```sh
+$ mix upload.hotswap --node example@nerves.local
+```
+
+This `--node` option can be used multiple times.
+
 ## Acknowledgement
 
 [Using Erlang Distribution to test hardware - Embedded Elixir](https://embedded-elixir.com/post/2018-12-10-using-distribution-to-test-hardware/) inspired me how to implement this package.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,19 @@ $ mix upload.hotswap --node example@nerves.local
 
 This `--node` option can be used multiple times.
 
+#### --module
+
+You can specify the module(s) as below:
+
+```sh
+$ mix upload.hotswap --module YourGoodApp
+```
+
+This `--module` option
+
+  - can be used multiple times.
+  - searches for all modules that start with the specified module name.
+
 ## Acknowledgement
 
 [Using Erlang Distribution to test hardware - Embedded Elixir](https://embedded-elixir.com/post/2018-12-10-using-distribution-to-test-hardware/) inspired me how to implement this package.

--- a/lib/mix/tasks/mix/tasks/upload/hotswap.ex
+++ b/lib/mix/tasks/mix/tasks/upload/hotswap.ex
@@ -7,7 +7,9 @@ defmodule Mix.Tasks.Upload.Hotswap do
   @config_key :mix_tasks_upload_hotswap
 
   @shortdoc "Deploy local code changes to the remote node(s) in a hot-code-swapping manner"
-  def run(_) do
+  def run(args) do
+    opts = parse_args(args)
+
     app_name = get_config_for(:app_name)
     nodes = get_config_for(:nodes)
     cookie = get_config_for(:cookie)
@@ -22,15 +24,38 @@ defmodule Mix.Tasks.Upload.Hotswap do
 
     {:ok, modules} = :application.get_key(app_name, :modules)
 
+    target_nodes =
+      if is_nil(opts[:node]) do
+        nodes
+      else
+        targets =
+          Keyword.get_values(opts, :node)
+          |> Enum.map(&:"#{&1}")
+
+        Enum.filter(nodes, &(&1 in targets))
+      end
+
     # upload the modules twice to ensure the codes on the remote devices fully replaced
     # https://erlang.org/doc/reference_manual/code_loading.html#code-replacement
     for _ <- 0..1 do
       for module <- modules do
-        for node <- nodes do
-         handle_load_module(IEx.Helpers.nl([node], module), module, node)
+        for node <- target_nodes do
+          handle_load_module(IEx.Helpers.nl([node], module), module, node)
         end
       end
     end
+  end
+
+  @spec parse_args(args :: [String.t()]) :: OptionParser.parsed()
+  def parse_args(args) do
+    {opts, _, _} =
+      OptionParser.parse(args,
+        strict: [
+          node: :keep
+        ]
+      )
+
+    opts
   end
 
   defp get_config_for(key) do


### PR DESCRIPTION
Hi! I'm using your nice library, `mix_tasks_upload_hotswap` with my cluster.
This PR's motivations are to specify node and to filter modules.

### `--node` option

can specify a node in a cluster, like `mix upload.hotswap --node hoge@192.168.5.55`

### `--module` option

can filter modules, like `mix upload.hotswap --module Mg`.
This option search for all modules that start with the specified module name(support starts with `Elixir`).

### the log I used these options

```shell
mix upload.hotswap --node hoge@192.168.5.55 --module Mg
==> nerves
==> my_good_app

Nerves environment
  MIX_TARGET:   rpi4
  MIX_ENV:      dev

==> mix_tasks_upload_hotswap
Compiling 1 file (.ex)
Generated mix_tasks_upload_hotswap app
==> my_good_app
Generated my_good_app app
Successfully connected to hoge@192.168.5.55
Successfully connected to fuga@192.168.5.56
Successfully deployed Elixir.Mg.R7eDa16 to hoge@192.168.5.55
Successfully deployed Elixir.Mg.R7eDc16B to hoge@192.168.5.55
Successfully deployed Elixir.Mg.R7eMs4 to hoge@192.168.5.55
Successfully deployed Elixir.Mg.R7eRs4 to hoge@192.168.5.55
Successfully deployed Elixir.Mg.R7eSv4 to hoge@192.168.5.55
Successfully deployed Elixir.Mg.R7eYv2 to hoge@192.168.5.55
Successfully deployed Elixir.Mg.R7eDa16 to hoge@192.168.5.55
Successfully deployed Elixir.Mg.R7eDc16B to hoge@192.168.5.55
Successfully deployed Elixir.Mg.R7eMs4 to hoge@192.168.5.55
Successfully deployed Elixir.Mg.R7eRs4 to hoge@192.168.5.55
Successfully deployed Elixir.Mg.R7eSv4 to hoge@192.168.5.55
Successfully deployed Elixir.Mg.R7eYv2 to hoge@192.168.5.55
```
